### PR TITLE
Removing Combine framework

### DIFF
--- a/Sources/Checkpoint/Algorithms/FixedWindowCounter.swift
+++ b/Sources/Checkpoint/Algorithms/FixedWindowCounter.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Combine
 import Logging
 import Hummingbird
 import RediStack
@@ -27,8 +26,8 @@ public actor FixedWindowCounter {
 	// A logger set during Vapor initialization
 	public let logging: Logger?
 	
-	// The Combine Timer publishers
-	private var cancellable: AnyCancellable?
+	// The Timer
+	private var timer: Timer?
 	// Keys stored in a given time window
 	private var keys = Set<String>()
 	
@@ -37,12 +36,12 @@ public actor FixedWindowCounter {
 		self.storage = storage()
 		self.logging = logging?()
 		
-		self.cancellable = startWindow(havingDuration: self.configuration.timeWindowDuration.inSeconds,
+		self.timer = startWindow(havingDuration: self.configuration.timeWindowDuration.inSeconds,
 									   performing: resetWindow)
 	}
 	
 	deinit {
-		cancellable?.cancel()
+		timer?.invalidate()
 	}
 }
 

--- a/Sources/Checkpoint/Algorithms/SlidingWindowLog.swift
+++ b/Sources/Checkpoint/Algorithms/SlidingWindowLog.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Combine
 import Logging
 import Hummingbird
 import RediStack

--- a/Sources/Checkpoint/Algorithms/WindowBasedAlgorithm.swift
+++ b/Sources/Checkpoint/Algorithms/WindowBasedAlgorithm.swift
@@ -5,7 +5,6 @@
 //  Created by Adolfo Vera Blasco on 11/12/24.
 //
 
-import Combine
 import Foundation
 
 public typealias WindowBasedAction = () throws -> Void
@@ -13,23 +12,21 @@ public typealias WindowBasedAction = () throws -> Void
 /// For those algorithims thar works with fixed time windows.
 public protocol WindowBasedAlgorithm: Algorithm {
 	/// Start the timer for a given duration (time window)
-	func startWindow(havingDuration seconds: Double, performing action: @escaping WindowBasedAction) -> AnyCancellable
+	func startWindow(havingDuration seconds: Double, performing action: @escaping WindowBasedAction) -> Timer
 	/// Perfomrs the reset operation when the time windo ends.
 	func resetWindow() async throws
 }
 
 extension WindowBasedAlgorithm {
-	public func startWindow(havingDuration seconds: Double, performing action: @escaping WindowBasedAction) -> AnyCancellable {
-		let cancellable = Timer.publish(every: seconds, on: .main, in: .common)
-			.autoconnect()
-			.sink { _ in
-				do {
-					try action()
-				} catch let timerError {
-					self.logging?.error("🚨 Something wrong at timer: \(timerError.localizedDescription)")
-				}
+	public func startWindow(havingDuration seconds: Double, performing action: @escaping WindowBasedAction) -> Timer {
+		let timer = Timer.scheduledTimer(withTimeInterval: seconds, repeats: true) { _ in
+			do {
+				try action()
+			} catch let timerError {
+				self.logging?.error("🚨 Something wrong at timer: \(timerError.localizedDescription)")
 			}
+		}
 		
-		return cancellable
+		return timer
 	}
 }


### PR DESCRIPTION
Remove the `Combine` framework to allow deploy the package in Linux based servers.

The `Timer` now uses the `scheduledTimer` function instead of the `publisher`